### PR TITLE
Added idle/online statuses when there are players online

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,9 @@ client.on('ready', async () => {
       playerCount = 0;
     }
     client.user.setActivity(`${playerCount} Spieler online.`, { type: ActivityType.Watching });
-    console.log("updated activity to " + playerCount);
+    // Set status to idle when there is no player playing; set to online if there are players online (Note: Discord takes time to update statuses!)
+    client.user.setStatus(playerCount == 0 ? "idle" : "online"); 
+    console.log("updated activity to " + playerCount + " (Status: " + client.user.presence.status + ")");
   }
 
   // Update activity initially


### PR DESCRIPTION
Added a call to ```client.user.setStatus``` in ```updateActivity```-function to set bot status to either online or idle depending on ```playerCount```.

Why? Boredom and I like little details