### PR TITLE
Added PlayerCountGetter when DataTransmitter is offline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ PANEL_BASE_URL="https://panel.example.org/"
 SERVER_APPLICATION_ID="anyNumberButProbably1or2or3or4or5"
 SERVER_CLIENT_ID="dj28041orSomethingLikeThat"
 
+SCP_SERVER_TIMEOUT=300000
+
 CEDMOD_INSTANCE_ID="1234"
+
+SCPLISTKR_INSTANCE_ID="12345; scplist.kr instance id";
 
 ENDPOINT_URL="PATH FOR ENDPOINT SERVER (f.e.: / ; /endpoint)"

--- a/lib/BotCommands.js
+++ b/lib/BotCommands.js
@@ -2,14 +2,18 @@
 let callbacks = {};
 
 const init = client => {
-
     client.on('interactionCreate', async interaction => {
         if (!interaction.isChatInputCommand()) return;
 
         if (callbacks[interaction.commandName] != undefined) {
 
-            callbacks[interaction.commandName](interaction);
-
+            try {
+                callbacks[interaction.commandName](interaction);
+            } catch (e) {
+                let err = String("Command: /" + interaction.commandName + " faild: \n" + e.stack);
+                console.error(err);
+                interaction.channel.send({ embeds: [new EmbedBuilder().setColor(0xFF0000).setTitle("Ein Fehler ist aufgetreten!").setDescription(err.substring(0, 1900))] });
+            }
             return;
         }
     });

--- a/lib/CedMod.js
+++ b/lib/CedMod.js
@@ -1,10 +1,12 @@
+import util from 'util';
+import request from 'request';
 
+const requestPromise = util.promisify(request);
 
-async function request() {
-    let instanceId = process.env.CEDMOD_INSTANCE_ID;
-
+async function requestData(instanceId) {
+    
     const options = {
-        'method': 'OPTIONS',
+        'method': 'GET',
         'url': `https://queryws.cedmod.nl/Api/Realtime/QueryServers/GetPopulation?instanceId=${instanceId}`,
         'headers': {
             'Content-Type': 'application/json',
@@ -43,4 +45,4 @@ async function request() {
 }
 
 
-export default { request };
+export default { requestData };

--- a/lib/PlayerCountGetter.js
+++ b/lib/PlayerCountGetter.js
@@ -1,0 +1,31 @@
+import CedMod from "./CedMod.js";
+import SCPListKr from "./SCPListKr.js";
+
+
+const NEW_LINE = "µ";
+const PLAYER_COUNT = "%i";
+const defaultPlayers = `Spielerzahl: ${PLAYER_COUNT}${NEW_LINE}Die Spieler können im${NEW_LINE}Moment nicht abgerufen werden${NEW_LINE} ----------- ${NEW_LINE}Versuche es später${NEW_LINE}nocheinmal`
+
+/**
+ * 
+ * @returns {{provider?, playerCount?, playerList?, error?}}
+ */
+const tryGetPlayerList = async (cedModInstance, scpListInstance) => {
+    let { playerCount, players, success } = await CedMod.requestData(cedModInstance);
+
+    if (success)
+        return { provider: "cedmod", playerCount, playerList: players };
+
+    const scplistkr = await SCPListKr.getRequestPromise(scpListInstance).catch(console.error);
+
+    if (!scplistkr.players)
+        return { error: "Server ist nicht verfügbar" };
+
+    const scpListKrPlayerCount = Number.parseInt(scplistkr.players.split("/")[0]);
+
+    const scpListKrPlayers = defaultPlayers.replace(PLAYER_COUNT, scpListKrPlayerCount).split(NEW_LINE);
+
+    return { provider: "scplist.kr", playerCount: scpListKrPlayerCount, playerList: scpListKrPlayers };
+}
+
+export default { tryGetPlayerList };

--- a/lib/SCPListKr.js
+++ b/lib/SCPListKr.js
@@ -11,21 +11,10 @@ const onUpdate = (callback) => {
 
 const startGettingInfo = (serverId) => {
     const updateFunc = () => {
-        const options = {
-            method: 'GET',
-            url: `https://api.scplist.kr/api/servers/${serverId}`,
-            headers: { 'Accept': 'application/json' }
-        };
-
-        request(options, (error, response, body) => {
-            if (error) return;
-
-            const json = JSON.parse(body);
-
+        getRequestPromise(serverId).then((json) => {
             for (const listener of onChangeListeners)
                 listener(json);
-
-        });
+        }).catch(console.error);
     };
     intervalObject = setInterval(updateFunc, 60 * 1_000);
     updateFunc();
@@ -35,4 +24,24 @@ const stopGettingInfo = () => {
     clearInterval(intervalObject);
 }
 
-export default { stopGettingInfo, startGettingInfo, onUpdate };
+const getRequestPromise = (serverId) => {
+    return new Promise((res, rej) => {
+        const options = {
+            method: 'GET',
+            url: `https://api.scplist.kr/api/servers/${serverId}`,
+            headers: { 'Accept': 'application/json' }
+        };
+
+        request(options, (error, response, body) => {
+            if (error) rej(error);
+            try {
+                const json = JSON.parse(body);
+                res(json);
+            } catch (error) {
+                rej(error);
+            }
+        });
+    })
+}
+
+export default { stopGettingInfo, startGettingInfo, onUpdate, getRequestPromise };


### PR DESCRIPTION
Base functionality works with DataTransmitter v1.0.0 but for new event "MapGenerated" [v1.1.0 DataTransmitter](https://github.com/RadSton/DataTransmitter/releases/tag/1.1.0) is needed to work

- Made CedMod take in instanceId
- Added a function in SCPListKr for async getting
- Added PlayerCountGetter.js which gets called when the server doesnt send playerinfo in env.SCP_SERVER_TIMEOUT (5m def)
- Made Bot default status: "Warte auf Server" (dnd)
- Bot now checks every 1.5 minutes for CedMod/SCPListKr data when DataTransmitter is offline
- Added GET endpoint (env.ENPOINT_URL) which gives info: playerCount, players, date (last refreshed at), (MapSeed)
- When bot recieves "ServerAvailable" status is set to "Generiere Karte ..."
- When bot recieves "MapGenerated" status is set to "Warte auf Spieler ..." (like playerCount == 0)
- Added "Updated" section to /playerlist command